### PR TITLE
composer : raise TYPO3 dependancy requirements to enable installation into v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^9.5.17"
+        "typo3/cms-core": "^9.5.17 || ^10.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Actually you cannot composer require the extension in TYPO3 V10 cause of composer.json requirements 